### PR TITLE
Add Millisecond Support, improve parsing, add string building, Overhaul

### DIFF
--- a/UtcConverter.bas
+++ b/UtcConverter.bas
@@ -33,9 +33,7 @@ Private Const ISO8601UTCTimeZone As String = "Z"
 
 
 #If Mac Then
-
 #If VBA7 Then
-
 ' 64-bit Mac (2016)
 Private Declare PtrSafe Function utc_popen Lib "/usr/lib/libc.dylib" Alias "popen" _
     (ByVal utc_Command As String, ByVal utc_Mode As String) As LongPtr
@@ -47,7 +45,6 @@ Private Declare PtrSafe Function utc_feof Lib "/usr/lib/libc.dylib" Alias "feof"
     (ByVal utc_File As LongPtr) As LongPtr
 
 #Else
-
 ' 32-bit Mac
 Private Declare Function utc_popen Lib "libc.dylib" Alias "popen" _
     (ByVal utc_Command As String, ByVal utc_Mode As String) As Long
@@ -59,7 +56,7 @@ Private Declare Function utc_feof Lib "libc.dylib" Alias "feof" _
     (ByVal utc_File As Long) As Long
 
 #End If
-
+' End of Mac
 #ElseIf VBA7 Then
 ' Windows VBA7
 

--- a/UtcConverter.bas
+++ b/UtcConverter.bas
@@ -927,8 +927,8 @@ End Function
 ' String_BufferAppend
 ' Based on VBA-Tools\Jsonconverter's "json_BufferAppend" functions
 ' To use, your calling routine needs to store the input variables to be handed back.
-Private Sub String_BufferAppend(ByRef StringBufferIn As StringBufferCache, _
-                              ByRef string_Append As Variant)
+Private Sub String_BufferAppend(ByRef StringBufferIn As StringBufferCache _
+                                , ByRef string_Append As Variant)
     ' VBA can be slow to append strings due to allocating a new string for each append
     ' Instead of using the traditional append, allocate a large empty string and then copy string at append position
     '

--- a/UtcConverter.bas
+++ b/UtcConverter.bas
@@ -484,6 +484,36 @@ utc_ErrorHandling:
     Err.Raise 10014, "UtcConverter.ConvertToIso", "ISO 8601 conversion error: " & Err.Number & " - " & Err.Description
 End Function
 
+
+
+Private Function RoundUp(ByVal value As Double) As Long
+    Dim lngVal As Long
+    Dim deltaValue As Double
+    
+    lngVal = VBA.CLng(value)
+    deltaValue = lngVal - value
+        
+    If deltaValue < 0 Then
+        RoundUp = lngVal + 1
+    Else
+        RoundUp = lngVal
+    End If
+End Function
+Private Function RoundDown(ByVal value As Double) As Long
+    Dim lngVal As Long
+    Dim deltaValue As Double
+    
+    lngVal = VBA.CLng(value)
+    deltaValue = lngVal - value
+        
+    If deltaValue <= 0 Then
+        RoundDown = lngVal
+    Else
+        RoundDown = lngVal - 1
+    End If
+End Function
+
+
 ' ============================================= '
 ' Private Functions
 ' ============================================= '

--- a/UtcConverter.bas
+++ b/UtcConverter.bas
@@ -1,8 +1,8 @@
 Attribute VB_Name = "UtcConverter"
 ''
-' VBA-UTC v1.0.6
+' VBA-UTC v2.0.1
 ' (c) Tim Hall - https://github.com/VBA-tools/VBA-UtcConverter
-'
+' (c) hecon5 - 2022-08-30T16:00:20.540Z rewrites and updates.
 ' UTC/ISO 8601 Converter for VBA
 '
 ' Errors:
@@ -12,9 +12,25 @@ Attribute VB_Name = "UtcConverter"
 ' 10014 - ISO 8601 conversion error
 '
 ' @module UtcConverter
-' @author tim.hall.engr@gmail.com
+' @author tim.hall.engr@gmail.com, hecon5
 ' @license MIT (http://www.opensource.org/licenses/mit-license.php)
 '' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ '
+Option Compare Text
+Option Explicit
+
+' Spec details which make parsing easier, instead of calling and / or doing math every time.
+Private Const TotalHoursInDay As Double = 24
+Private Const TotalMinutesInDay As Double = TotalHoursInDay * 60
+Private Const TotalSecondsInDay As Double = TotalMinutesInDay * 60
+Private Const TotalMillisecondsInDay As Double = TotalSecondsInDay * 1000
+
+
+Private Const DecimalSeparator As String = "."
+Private Const ISO8601DateDelimiter As String = "-"
+Private Const ISO8601DateTimeSeparator As String = "T"
+Private Const ISO8601TimeDelimiter As String = ":"
+Private Const ISO8601UTCTimeZone As String = "Z"
+
 
 #If Mac Then
 

--- a/UtcConverter.bas
+++ b/UtcConverter.bas
@@ -222,12 +222,11 @@ End Type
 '       Windows time parsing has been extensively tested to return the correct value.
 ''
 Public Function ParseUtc(utc_UtcDate As Date) As Date
-' Changed to wrapper to allow legacy users to keep their names.
     ParseUtc = ConvertToLocalDate(utc_UtcDate)
 End Function
 
-' Renamed to be clearer to dev what this function does.
-Public Function ConvertToLocalDate(utc_UtcDate As Date) As Date
+
+Public Function ConvertToLocalDate(ByVal utc_UtcDate As Date) As Date
     On Error GoTo utc_ErrorHandling
 
 #If Mac Then


### PR DESCRIPTION
Added in millisecond support to `Date`. 
Added full parsing capabilities (Windows Only :( ) for parsing any ISO8601 string to `Date`.
Added TimeStamp output, either local or UTC.

Added ability to parse timestamp to either Local Date or UTC String out.

Added Dynamic TimeZone parsing (allows for dynamic time zone use and correctly parses for a given year).

Added `TimeSerialDbl` to allow and facilitate building `Date` types with partial Hours/Minutes/Seconds.

Other Speed and consistency updates.